### PR TITLE
Show Traffic Lights as default view

### DIFF
--- a/app/src/main/java/com/futurice/android/reservator/AccountSelection.java
+++ b/app/src/main/java/com/futurice/android/reservator/AccountSelection.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 
 public class AccountSelection extends ReservatorActivity {
 	static final int REQUEST_LOBBY = 0;
+	static final int REQUEST_FAV_ROOM = 1;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -36,6 +37,7 @@ public class AccountSelection extends ReservatorActivity {
 
 	public void moveToLobby() {
 		Intent i = new Intent(this, LobbyActivity.class);
+		i.setAction(LobbyActivity.ACTION_FAV_ROOM);
 		startActivityForResult(i, REQUEST_LOBBY);
 	}
 

--- a/app/src/main/java/com/futurice/android/reservator/LobbyActivity.java
+++ b/app/src/main/java/com/futurice/android/reservator/LobbyActivity.java
@@ -7,17 +7,13 @@ import java.util.Vector;
 
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
-import android.app.Dialog;
-import android.app.DialogFragment;
 import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.Html;
 import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
@@ -41,6 +37,9 @@ import com.futurice.android.reservator.view.LobbyReservationRowView.OnReserveLis
 
 public class LobbyActivity extends ReservatorActivity implements OnMenuItemClickListener,
 		DataUpdatedListener, AddressBookUpdatedListener {
+
+	static final String ACTION_FAV_ROOM = "com.futurice.android.reservator.LobbyActivity.action.FAV_ROOM";
+
 	MenuItem settingsMenu, refreshMenu, aboutMenu;
 	LinearLayout container = null;
 	DataProxy proxy;
@@ -63,6 +62,11 @@ public class LobbyActivity extends ReservatorActivity implements OnMenuItemClick
 		ab = this.getResApplication().getAddressBook();
 		DigitalClock clock =  (DigitalClock)findViewById(R.id.digitalClock1);  //FIXME deprecated
         clock.setTypeface(Typeface.createFromAsset(getAssets(), "fonts/EHSMB.TTF"));
+
+		Intent intent = getIntent();
+		if (intent.getAction() != null || intent.equals(ACTION_FAV_ROOM)) {
+			immediatelyGoToFavouriteRoom();
+		}
 	}
 
 	@Override

--- a/app/src/main/java/com/futurice/android/reservator/ReservatorActivity.java
+++ b/app/src/main/java/com/futurice/android/reservator/ReservatorActivity.java
@@ -1,15 +1,14 @@
 package com.futurice.android.reservator;
 
-import com.futurice.android.reservator.ReservatorApplication;
-import com.futurice.android.reservator.model.ReservatorException;
-import com.futurice.android.reservator.model.Room;
-
 import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.view.WindowManager;
 import android.widget.Toast;
+
+import com.futurice.android.reservator.model.ReservatorException;
+import com.futurice.android.reservator.model.Room;
 
 public class ReservatorActivity extends Activity {
 
@@ -94,13 +93,19 @@ public class ReservatorActivity extends Activity {
 
 	private void startAutoGoToFavouriteRoom() {
 		if (isPrehensible()){
-			handler.postDelayed(goToFavouriteRoomRunable, 60000);
+			handler.postDelayed(goToFavouriteRoomRunable, 20000);
 		}
 	}
 
 	private void stopAutoGoToFavouriteRoom() {
 		if (isPrehensible()){
 			handler.removeCallbacks(goToFavouriteRoomRunable);
+		}
+	}
+
+	void immediatelyGoToFavouriteRoom() {
+		if (isPrehensible()){
+			handler.postDelayed(goToFavouriteRoomRunable, 0);
 		}
 	}
 

--- a/app/src/main/java/com/futurice/android/reservator/RoomActivity.java
+++ b/app/src/main/java/com/futurice/android/reservator/RoomActivity.java
@@ -98,7 +98,9 @@ public class RoomActivity extends ReservatorActivity implements OnMenuItemClickL
 				new OnClickListener() {
 					@Override
 					public void onClick(View v) {
-						RoomActivity.this.finish();
+						Intent intent = new Intent(RoomActivity.this, LobbyActivity.class);
+						intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+						startActivity(intent);
 					}
 				});
 
@@ -198,12 +200,12 @@ public class RoomActivity extends ReservatorActivity implements OnMenuItemClickL
 			@Override
 			public void onReservationClick(View v, Reservation reservation) {
 				final EditReservationPopup d = new EditReservationPopup(RoomActivity.this, reservation, currentRoom,
-					new EditReservationPopup.OnReservationCancelledListener() {
-						@Override
-						public void onReservationCancelled(Reservation r) {
-							refreshData();
-						}
-					});
+						new EditReservationPopup.OnReservationCancelledListener() {
+							@Override
+							public void onReservationCancelled(Reservation r) {
+								refreshData();
+							}
+						});
 
 				RoomActivity.this.trafficLights.disable();
 				d.setOnDismissListener(new OnDismissListener() {
@@ -212,7 +214,7 @@ public class RoomActivity extends ReservatorActivity implements OnMenuItemClickL
 						RoomActivity.this.trafficLights.enable();
 					}
 				});
-				
+
 				d.show();
 			}
 		});
@@ -225,6 +227,7 @@ public class RoomActivity extends ReservatorActivity implements OnMenuItemClickL
 	 */
 	public static void startWith(Context context, Room room) {
 		Intent i = new Intent(context, RoomActivity.class);
+		i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 		i.putExtra(ROOM_EXTRA, room);
 		context.startActivity(i);
 	}

--- a/app/src/main/java/com/futurice/android/reservator/view/RoomTrafficLights.java
+++ b/app/src/main/java/com/futurice/android/reservator/view/RoomTrafficLights.java
@@ -182,6 +182,7 @@ public class RoomTrafficLights extends RelativeLayout {
 	public void enable() {
 		enabled = true;
 		lastTouched = new Date().getTime();
+		RoomTrafficLights.this.setVisibility(VISIBLE);
 		scheduleTimer();
 	}
 


### PR DESCRIPTION
Changed activity flow so RoomActivity immediately launches with Traffic
Lights on app start. Traffic Lights now behaves like a “home screen”.
